### PR TITLE
Added git bash command

### DIFF
--- a/batchbin/casperjs
+++ b/batchbin/casperjs
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export CASPER_PATH=$(dirname $0)/..
+export CASPER_BIN=$CASPER_PATH/bin
+phantomjs $CASPER_BIN/bootstrap.js --casper-path=$CASPER_PATH --cli $1


### PR DESCRIPTION
I've added a shell script to use CasperJS with Unix on Windows (i.e. Git Bash):

$ casperjs test.js

CasperJS already ships with a Windows batch script to use it without Python nor Ruby. However, that script only works from within Windows command line (or from utilities such as grunt).
