### PR TITLE
Allow to get a property of a remote object

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1081,8 +1081,16 @@ Casper.prototype.getGlobal = function getGlobal(name) {
     this.checkStarted();
     var result = this.evaluate(function _evaluate(name) {
         var result = {};
+        var keys = name.replace(/\[/g, ".").replace(/\]/g, '').split('.');
+        var value = window;
+        keys.forEach(function (key) {
+            key = key.replace(/'/g, '').replace(/"/g, '').replace(/"/g, '');
+            if (!/^\s*$/.test(key)) {
+                value = value[key];
+            }
+        });
         try {
-            result.value = JSON.stringify(window[name]);
+            result.value = JSON.stringify(value);
         } catch (e) {
             var message = "Unable to JSON encode window." + name + ": " + e;
             __utils__.log(message, "error");

--- a/tests/suites/casper/global.js
+++ b/tests/suites/casper/global.js
@@ -1,11 +1,13 @@
 /*global casper*/
 /*jshint strict:false*/
-casper.test.begin('getGLobal() tests', 3, function(test) {
+casper.test.begin('getGLobal() tests', 4, function(test) {
     casper.start('tests/site/global.html', function() {
         test.assertEquals(this.getGlobal('myGlobal'), 'awesome string',
             'Casper.getGlobal() can retrieve a remote global variable');
         test.assertEquals(this.getGlobal('myObject').foo.bar, 'baz',
             'Casper.getGlobal() can retrieves a serializable object');
+        test.assertEquals(this.getGlobal('myObject["foo"].bar'), 'baz',
+            'Casper.getGlobal() can retrieves a remote sub-property');
         test.assertRaises(this.getGlobal, ['myUnencodableGlobal'],
             'Casper.getGlobal() does not fail trying to encode an unserializable global');
     }).run(function() {


### PR DESCRIPTION
This allow to get a property of a remote object.

Usage: 

```js
Casper.getGlobal('foo[0].bar.baz');
```

(in my use case, I can not use `Casper.getGlobal('foo')[0].bar.baz` because foo contains circular references and `JSON.stringify` fails).

I presume this patch is not a very good idea, too complex, and I should just use evaluate to get the property I need.