### PR TITLE
Introduced new Exporter system

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -1485,12 +1485,14 @@ Tester.prototype.renderFailureDetails = function renderFailureDetails() {
  *
  * @param  Boolean  exit    Exit casper after results have been rendered?
  * @param  Number   status  Exit status code (default: 0)
- * @param  String   save    Optional path to file where to save the results log
+ * @param  String   format  Format type [xunit|html]
+ * @param  String   file    Optional path to file where to save the results log
  */
-Tester.prototype.renderResults = function renderResults(exit, status, save) {
+Tester.prototype.renderResults = function renderResults(exit, status, format, file) {
     "use strict";
     /*jshint maxstatements:25*/
-    save = save || this.options.save;
+    format = format || this.options.format;
+    file = file || this.options.file;
     var exitStatus = 0,
         failed = this.suiteResults.countFailed(),
         total = this.suiteResults.countExecuted(),
@@ -1523,8 +1525,8 @@ Tester.prototype.renderResults = function renderResults(exit, status, save) {
     }
     this.casper.echo(result, style, this.options.pad);
     this.renderFailureDetails();
-    if (save) {
-        this.saveResults(save);
+    if (format && file) {
+        this.saveResults(format, file);
     }
     if (exit === true) {
         this.emit("exit");
@@ -1613,14 +1615,15 @@ Tester.prototype.terminate = function(message) {
 /**
  * Saves results to file.
  *
- * @param  String  filename  Target file path.
+ * @param  String  format    [xunit|html]
+ * @param  String  filepath      Target file path
  */
-Tester.prototype.saveResults = function saveResults(filepath) {
+Tester.prototype.saveResults = function saveResults(format, filepath) {
     "use strict";
-    var exporter = require('xunit').create();
+    var exporter = require(format).create();
     exporter.setResults(this.suiteResults);
     try {
-        fs.write(filepath, exporter.getSerializedXML(), 'w');
+        fs.write(filepath, exporter.render(), 'w');
         this.casper.echo(f('Result log stored in %s', filepath), 'INFO', 80);
     } catch (e) {
         this.casper.echo(f('Unable to write results to %s: %s', filepath, e), 'ERROR', 80);

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -714,13 +714,14 @@ function ms2seconds(milliseconds) {
 exports.ms2seconds = ms2seconds;
 
 /**
- * Creates an (SG|X)ML node element.
+ * Creates an (SG|X|HT)ML node element.
  *
  * @param  String  name        The node name
  * @param  Object  attributes  Optional attributes
+ * @param  String text  Optional text inside HTMLElement
  * @return HTMLElement
  */
-function node(name, attributes) {
+function node(name, attributes, text) {
     "use strict";
     var _node   = document.createElement(name);
     for (var attrName in attributes) {
@@ -729,6 +730,11 @@ function node(name, attributes) {
             _node.setAttribute(attrName, value);
         }
     }
+    if(text) {
+        var textNode = document.createTextNode(text);
+        _node.appendChild(textNode);
+    }
+
     return _node;
 }
 exports.node = node;

--- a/modules/xunit.js
+++ b/modules/xunit.js
@@ -90,7 +90,7 @@ exports.XUnitExporter = XUnitExporter;
  *
  * @return HTMLElement
  */
-XUnitExporter.prototype.getXML = function getXML() {
+XUnitExporter.prototype.render = function render() {
     "use strict";
     if (!(this.results instanceof TestSuiteResult)) {
         throw new CasperError('Results not set, cannot get XML.');
@@ -150,7 +150,7 @@ XUnitExporter.prototype.getXML = function getXML() {
         this._xml.appendChild(suiteNode);
     }.bind(this));
     this._xml.setAttribute('time', utils.ms2seconds(this.results.calculateDuration()));
-    return this._xml;
+    return this.getSerializedXML(this._xml);
 };
 
 /**
@@ -161,7 +161,7 @@ XUnitExporter.prototype.getXML = function getXML() {
 XUnitExporter.prototype.getSerializedXML = function getSerializedXML(xml) {
     "use strict";
     var serializer = new XMLSerializer();
-    return '<?xml version="1.0" encoding="UTF-8"?>' + serializer.serializeToString(this.getXML());
+    return '<?xml version="1.0" encoding="UTF-8"?>' + serializer.serializeToString(xml);
 }
 
 /**

--- a/tests/run.js
+++ b/tests/run.js
@@ -101,7 +101,15 @@ function initRunner() {
 
     // test suites completion listener
     casper.test.on('tests.complete', function() {
-        this.renderResults(this.options.autoExit, undefined, casper.cli.get('xunit') || undefined);
+        var format = casper.cli.get('format') || undefined;
+        var file = casper.cli.get('file') || undefined;
+
+        // ensure BC on --xunit option 
+        if (casper.cli.has('xunit')) {
+            format = 'xunit';
+            file = casper.cli.get('xunit');
+        }
+        this.renderResults(this.options.autoExit, undefined, format, file);
         if (this.options.failFast && this.testResults.failures.length > 0) {
             casper.warn('Test suite failed fast, all tests may not have been executed.');
         }

--- a/tests/suites/xunit.js
+++ b/tests/suites/xunit.js
@@ -7,7 +7,7 @@ casper.test.begin('XUnitReporter() initialization', 1, function suite(test) {
     var xunit = require('xunit').create();
     var results = new tester.TestSuiteResult();
     xunit.setResults(results);
-    test.assertTruthy(xunit.getSerializedXML());
+    test.assertTruthy(xunit.render());
     test.done();
 });
 
@@ -25,7 +25,7 @@ casper.test.begin('XUnitReporter() can hold test suites', 4, function suite(test
     });
     results.push(suite2);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
+    casper.start().setContent(xunit.render());
     test.assertEvalEquals(function() {
         return __utils__.findAll('testsuite').length;
     }, 2);
@@ -50,7 +50,7 @@ casper.test.begin('XUnitReporter() can hold a suite with a succesful test', 1, f
     });
     results.push(suite1);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
+    casper.start().setContent(xunit.render());
     test.assertExists('testsuite[name="foo"][package="foo"][tests="1"][failures="0"] testcase[name="footext"]');
     test.done();
 });
@@ -70,7 +70,7 @@ casper.test.begin('XUnitReporter() can handle a failed test', 2, function suite(
     });
     results.push(suite1);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
+    casper.start().setContent(xunit.render());
     test.assertExists('testsuite[name="foo"][package="foo"][tests="1"][failures="1"] testcase[name="footext"] failure[type="footype"]');
     test.assertEquals(casper.getElementInfo('failure[type="footype"]').text, 'footext');
     test.done();


### PR DESCRIPTION
See #763 

So I've splitted my proposal into 2 contributions:
* this one which introduce a refactoring of export system (with BC) to allow the implementation of new exporters

-> allow the exporters MUST have render() method which return the correct output.

As a sample, I will - after this contribution to be merged - add a new HTML/PHPUnit-like exporter