### PR TITLE
refs #803 - Add option to create a new WebPage instance from casper

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -1290,6 +1290,28 @@ Supported events are ``mouseup``, ``mousedown``, ``click``, ``mousemove``, ``mou
 
     casper.run();
 
+``newPage()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``newPage()``
+
+.. versionadded:: 1.1
+
+Creates a new WebPage instance::
+
+    casper.start('http://google.com', function() {
+        // ...
+    });
+
+    casper.then(function() {
+        casper.page = casper.newPage();
+        casper.open('http://yahoo.com').then( function() {
+            // ....
+        });
+    });
+
+    casper.run();
+
 .. index:: HTTP, HTTP Request, HTTP Method, HTTP Headers
 
 ``open()``

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2403,7 +2403,17 @@ Casper.prototype.withPopup = function withPopup(popupInfo, then) {
 
 Casper.prototype.newPage = function newPage() {
     "use strict";
-    return createPage(this);
+    this.checkStarted();
+    this.page.close();        
+    this.page = this.mainPage = createPage(this);
+    this.page.settings = utils.mergeObjects(this.page.settings, this.options.pageSettings);
+    if (utils.isClipRect(this.options.clipRect)) {
+        this.page.clipRect = this.options.clipRect;
+    }
+    if (utils.isObject(this.options.viewportSize)) {
+        this.page.viewportSize = this.options.viewportSize;
+    }
+    return this.page;
 };
 
 /**

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2404,7 +2404,7 @@ Casper.prototype.withPopup = function withPopup(popupInfo, then) {
 Casper.prototype.newPage = function newPage() {
     "use strict";
     this.checkStarted();
-    this.page.close();        
+    this.page.close();
     this.page = this.mainPage = createPage(this);
     this.page.settings = utils.mergeObjects(this.page.settings, this.options.pageSettings);
     if (utils.isClipRect(this.options.clipRect)) {

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2397,6 +2397,16 @@ Casper.prototype.withPopup = function withPopup(popupInfo, then) {
 };
 
 /**
+* Allow user to create a new page object after calling a casper.page.close()
+* @return WebPage
+*/
+
+Casper.prototype.newPage = function newPage() {
+    "use strict";
+    return createPage(this);
+};
+
+/**
  * Changes the current page zoom factor.
  *
  * @param  Number  factor  The zoom factor

--- a/tests/suites/casper/newpage.js
+++ b/tests/suites/casper/newpage.js
@@ -1,0 +1,24 @@
+/*global casper*/
+/*jshint strict:false*/
+casper.test.begin('newPage() tests', 5, function(test) {
+    casper.start('tests/site/index.html', function() {
+        test.assertTitle('CasperJS test index', 'Casper.start() opened the first page');
+        test.assertEval(function() {
+            return typeof(__utils__) === "object";
+        }, 'Casper.start() injects ClientUtils instance within remote DOM');
+    }).then(function(){
+        casper.newPage();
+        casper.thenOpen('tests/site/page1.html', function(){
+            test.assertTitle('CasperJS test page 1', 'casper.newPage() created a new page object');
+            test.assertEval(function() {
+                return typeof(__utils__) === "object";
+            }, 'Casper.newPage() injects ClientUtils instance within remote DOM');
+           });
+    }).run(function() {
+        test.done();
+    });
+
+    test.assert(casper.started, 'Casper.start() started');
+
+
+});

--- a/tests/suites/casper/newpage.js
+++ b/tests/suites/casper/newpage.js
@@ -17,8 +17,5 @@ casper.test.begin('newPage() tests', 5, function(test) {
     }).run(function() {
         test.done();
     });
-
     test.assert(casper.started, 'Casper.start() started');
-
-
 });


### PR DESCRIPTION
Currently casperjs does not handle closing a page and creating a new
page object. 

If user does a casper.page.close() there is no option to create a new
page object.

With this change we can use a casper.page = casper.newPage()