### PR TITLE
Change type for assertNotVisible

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -667,7 +667,7 @@ Tester.prototype.assertNotVisible =
 Tester.prototype.assertInvisible = function assertNotVisible(selector, message) {
     "use strict";
     return this.assert(!this.casper.visible(selector), message, {
-        type: "assertVisible",
+        type: "assertNotVisible",
         standard: "Selector is not visible",
         values: {
             selector: selector


### PR DESCRIPTION
Seeing the 'assertVisible' type in the test report can be very confusing.  I've changed the type to 'assertNotVisible' to match the actual assertion name.