### PR TITLE
fixed phantom.args for phantomjs 2.x

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -40,7 +40,16 @@ if ('process' in this && process.title === "node") {
 // phantom check
 if (!('phantom' in this)) {
     console.error('CasperJS needs to be executed in a PhantomJS environment http://phantomjs.org/');
+} else {
+    if (phantom.version.major === 2) {
+        //setting other phantom.args if using phantomjs 2.x
+        var system = require('system');
+        var argsdeprecated = system.args;
+        argsdeprecated.shift();
+        phantom.args = argsdeprecated;
+    }
 }
+
 
 // Common polyfills
 if (typeof Function.prototype.bind !== "function") {


### PR DESCRIPTION
@n1k0 this works for me for the phantomjs 2.0 version.
I'm not sure, if it would work for the 1.x version, so that's why I checked it that early only to set the phantom.args