### PR TITLE
Fixes #1182 - Allow waitFor timeout exception to propagate

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2121,14 +2121,13 @@ Casper.prototype.waitFor = function waitFor(testFx, then, onTimeout, timeout, de
                     if (!self.options.silentErrors) {
                         throw error;
                     }
-                } finally {
-                    return;
                 }
-            }
-            self.log(f("waitFor() finished in %dms.", new Date().getTime() - start), "info");
-            clearInterval(interval);
-            if (then) {
-                self.then(then);
+            } else {
+                self.log(f("waitFor() finished in %dms.", new Date().getTime() - start), "info");
+                clearInterval(interval);
+                if (then) {
+                    self.then(then);
+                }
             }
         }, this.options.retryTimeout, this);
         this.waiters.push(interval);


### PR DESCRIPTION
Removed the finally block and moved the code that is not intended to execute into an else block