### PR TITLE
fix xpath error message

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1058,9 +1058,9 @@ Casper.prototype.getElementInfo = function getElementInfo(selector) {
     this.checkStarted();
     if (!this.exists(selector)) {
         if (utils.isObject(selector) && selector.type === 'xpath') {
-            throw new CasperError(f("Cannot get information from %s: no elements found.", selector.path));
+            throw new CasperError(f("Cannot get information from %s: element not found.", selector.path));
         } else {
-            throw new CasperError(f("Cannot get information from %s: no elements found.", selector));
+            throw new CasperError(f("Cannot get information from %s: element not found.", selector));
         }
     }
     return this.callUtils("getElementInfo", selector);

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1057,7 +1057,11 @@ Casper.prototype.getElementInfo = function getElementInfo(selector) {
     "use strict";
     this.checkStarted();
     if (!this.exists(selector)) {
-        throw new CasperError(f("Cannot get informations from %s: element not found.", selector));
+        if (utils.isObject(selector) && selector.type === 'xpath') {
+            throw new CasperError(f("Cannot get information from %s: no elements found.", selector.path));
+        } else {
+            throw new CasperError(f("Cannot get information from %s: no elements found.", selector));
+        }
     }
     return this.callUtils("getElementInfo", selector);
 };
@@ -1072,7 +1076,11 @@ Casper.prototype.getElementsInfo = function getElementsInfo(selector) {
     "use strict";
     this.checkStarted();
     if (!this.exists(selector)) {
-        throw new CasperError(f("Cannot get information from %s: no elements found.", selector));
+        if (utils.isObject(selector) && selector.type === 'xpath') {
+            throw new CasperError(f("Cannot get information from %s: no elements found.", selector.path));
+        } else {
+            throw new CasperError(f("Cannot get information from %s: no elements found.", selector));
+        }
     }
     return this.callUtils("getElementsInfo", selector);
 };


### PR DESCRIPTION
Hi,

When doing something like this:


            var selector = {
                type: 'xpath',
                path: '//*[@class="plop"]'
            };
            var info = casper.getElementInfo(selector);

Where selector is an element that does not exist, the error reported looks like this:

`CasperError: Cannot get informations from [object Object]: element not found.`

It would be very helpful if the error reported the XPath selector path in the error, instead of `[object Object]`.