### PR TITLE
Fix fetchText() returning "undefined" for empty elements

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -230,7 +230,7 @@
             var text = '', elements = this.findAll(selector);
             if (elements && elements.length) {
                 Array.prototype.forEach.call(elements, function _forEach(element) {
-                    text += element.textContent || element.innerText || element.value;
+                    text += element.textContent || element.innerText || element.value || '';
                 });
             }
             return text;

--- a/tests/suites/casper/fetchtext.js
+++ b/tests/suites/casper/fetchtext.js
@@ -27,3 +27,14 @@ casper.test.begin('fetchText() handles HTML entities', 1, function(test) {
         test.done();
     });
 });
+
+casper.test.begin('fetchText() handles empty elements', 1, function(test) {
+    casper.start().then(function() {
+        this.setContent('<html><body></body></html>');
+        test.assertEquals(this.fetchText('body'), '',
+            'Casper.fetchText() fetches empty string');
+    });
+    casper.run(function() {
+        test.done();
+    });
+});


### PR DESCRIPTION
This resolves #1206 

A PR was merged on [Nov 3rd, 2014] (https://github.com/n1k0/casperjs/commit/bb706acdf38f30d2380ebd3897ba1d4cee74430c) that updated the fetchText() function to [also check the element's value attribute](https://github.com/n1k0/casperjs/commit/bb706acdf38f30d2380ebd3897ba1d4cee74430c) (when the inner text/html is empty) -- which was a nice improvement! However, if the OR logic makes it to `element.value` and the value attribute is undefined (as it often is for non-input elements), then the result ends up being the string "undefined", instead of an empty string.

For example, if you have `<p id="test"></p>`, the result of `casper.fetchText('#test')` will be the string "undefined", not "". (This appears to be the result of JavaScript converting an undefined value to a string.)

This PR fixes the issue and includes a test for it.