### PR TITLE
refs #1290: Infinitely loops when call casper.warn()

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -1958,11 +1958,10 @@ TestCaseResult.prototype.addSkip = function addSkip(skipped, time) {
 /**
  * Adds a warning record.
  *
- * @param Object  warning
+ * @param String  warning
  */
 TestCaseResult.prototype.addWarning = function addWarning(warning) {
     "use strict";
-    warning.suite = this.name;
     this.warnings.push(warning);
 };
 


### PR DESCRIPTION
All the usage is to treat warning as a string. Trying to assign a property to a string would trigger an uncaughtError exception. Besides, xunit.js also uses warnings as a string array to join them together.