### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,10 +49,17 @@ Installing from npm
 
 .. versionadded:: 1.1-beta3
 
-You can install CasperJS using `npm <http://npmjs.org/>`_::
+You can install CasperJS using `npm <http://npmjs.org/>`_:
 
-    For beta3: $ npm install -g casperjs@1.1.0-beta3
-    For beta2: $ npm install -g casperjs@1.1.0-beta2
+- For most users:
+
+    $ npm install -g casperjs
+    
+- If want specific version:
+
+    - For beta3: $ npm install -g casperjs@1.1.0-beta3
+
+    - For beta2: $ npm install -g casperjs@1.1.0-beta2
 
 .. note::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,8 @@ Installing from npm
 
 You can install CasperJS using `npm <http://npmjs.org/>`_::
 
-    $ npm install -g casperjs
+    For beta3: $ npm install -g casperjs@1.1.0-beta3
+    For beta2: $ npm install -g casperjs@1.1.0-beta2
 
 .. note::
 


### PR DESCRIPTION
If I just run `npm install -g casperjs` I get an error about no compatible targets (full message at http://pastebin.com/zAdpTtdB)

The way to fix this is add the @VERSION to the npm but some people might be too scared of the error message to really understand it. I think the clearer way is to show the possible examples from the doc.

I'd like to include a little information about which version (beta2 or beta3) should be chosen but I don't know enough about the differences.

Cheers!