### PR TITLE
Add enclosing double quotes on path arguments. Fix #1180.

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -127,8 +127,8 @@ for arg in SYS_ARGS:
 CASPER_COMMAND = [ENGINE_EXECUTABLE]
 CASPER_COMMAND.extend(ENGINE_ARGS)
 CASPER_COMMAND.extend([
-    os.path.join(CASPER_PATH, 'bin', 'bootstrap.js'),
-    '--casper-path=%s' % CASPER_PATH,
+    '"%s"' % os.path.join(CASPER_PATH, 'bin', 'bootstrap.js'),
+    '--casper-path="%s"' % CASPER_PATH,
     '--cli'
 ])
 CASPER_COMMAND.extend(CASPER_ARGS)


### PR DESCRIPTION
I couldn't use casperjs in a path with spaces through NPM run scripts on Windows 8.1.
This simple commit encloses the path in double quotes so that the space do not be interpreted as an additional parameter.

We could escape the space with a backslash too I think.