### PR TITLE
Allow form fill to find select element values by their option elements text as well as value

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -886,7 +886,7 @@
                         });
 
                         // If the values can't be found, try search options text
-                        if (field.value == "") {
+                        if (field.value === "") {
                           [].forEach.call(field.options, function(option) {
                                 option.selected = value.indexOf(option.text) !== -1;
                           });
@@ -897,8 +897,8 @@
                       // If the value can't be found, try search options text
                       if (field.value !== value) {
                         [].some.call(field.options, function(option) {
-                              option.selected = value == option.text;
-                              return value == option.text;
+                              option.selected = value === option.text;
+                              return value === option.text;
                         });
                       }
                     }

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -884,8 +884,23 @@
                         [].forEach.call(field.options, function(option) {
                             option.selected = value.indexOf(option.value) !== -1;
                         });
+
+                        // If the values can't be found, try search options text
+                        if (field.value == "") {
+                          [].forEach.call(field.options, function(option) {
+                                option.selected = value.indexOf(option.text) !== -1;
+                          });
+                        }
                     } else {
                       field.value = value;
+
+                      // If the value can't be found, try search options text
+                      if (field.value !== value) {
+                        [].some.call(field.options, function(option) {
+                              option.selected = value == option.text;
+                              return value == option.text;
+                        });
+                      }
                     }
                     break;
                 case "textarea":

--- a/tests/suites/casper/formfill.js
+++ b/tests/suites/casper/formfill.js
@@ -35,10 +35,11 @@ function testUrl(test) {
     test.assertUrlMatch(/check=on/, 'input[type=checkbox] field was submitted');
     test.assertUrlMatch(/choice=no/, 'input[type=radio] field was submitted');
     test.assertUrlMatch(/topic=bar/, 'select field was submitted');
+    test.assertUrlMatch(/multitopic=bar&multitopic=car/, 'multitopic select fields were submitted');
     test.assertUrlMatch(/strange=very/, 'strangely typed input field was submitted');
 }
 
-casper.test.begin('fill() & fillNames() tests', 17, function(test) {
+casper.test.begin('fill() & fillNames() tests', 18, function(test) {
     var fpath = fs.pathJoin(phantom.casperPath, 'README.md');
 
     casper.start('tests/site/form.html', function() {
@@ -67,7 +68,7 @@ casper.test.begin('fill() & fillNames() tests', 17, function(test) {
     });
 });
 
-casper.test.begin('fillLabels() tests', 17, function(test) {
+casper.test.begin('fillLabels() tests', 18, function(test) {
     var fpath = fs.pathJoin(phantom.casperPath, 'README.md');
 
     casper.start('tests/site/form.html', function() {
@@ -97,7 +98,7 @@ casper.test.begin('fillLabels() tests', 17, function(test) {
     });
 });
 
-casper.test.begin('fillSelectors() tests', 17, function(test) {
+casper.test.begin('fillSelectors() tests', 18, function(test) {
     var fpath = fs.pathJoin(phantom.casperPath, 'README.md');
 
     casper.start('tests/site/form.html', function() {
@@ -126,7 +127,7 @@ casper.test.begin('fillSelectors() tests', 17, function(test) {
     });
 });
 
-casper.test.begin('fillXPath() tests', 16, function(test) {
+casper.test.begin('fillXPath() tests', 17, function(test) {
     casper.start('tests/site/form.html', function() {
         this.fillXPath('form[action="result.html"]', {
             '//input[@name="email"]':       'chuck@norris.com',
@@ -260,6 +261,26 @@ casper.test.begin('getFormValues() tests', 2, function(test) {
             "multitopic": ["bar", "car"],
             "strange": "very"
         }, 'Casper.getFormValues() correctly retrieves values from radio inputs regardless of order');
+    });
+    casper.run(function() {
+        test.done();
+    });
+});
+
+casper.test.begin('fillSelectors() tests', 4, function(test) {
+    var fpath = fs.pathJoin(phantom.casperPath, 'README.md');
+
+    casper.start('tests/site/form.html', function() {
+        this.fillSelectors('form[action="result.html"]', {
+            "select[name='topic']":       'baz',
+            "select[name='multitopic']":  ['baz', 'caz'],
+        });
+        test.assertField('topic', 'bar', 'can pick a value from a select form field by text value');
+        test.assertField('multitopic', ['bar', 'car'], 'can pick a set of values from a multiselect form field by text value');
+    });
+    casper.thenClick('input[type="submit"]', function() {
+        test.assertUrlMatch(/topic=bar/, 'select field was submitted');
+        test.assertUrlMatch(/multitopic=bar&multitopic=car/, 'multitopic select fields were submitted');
     });
     casper.run(function() {
         test.done();


### PR DESCRIPTION
Currently, using the form fill helper requires one to specify the values for a select element, but at times we may not know the value, but we will know the text of the option we want to select.

This will also make the test more legible, as the value specified in the test will be the same as the value the user would look for and choose in the browser.

I also added url matching to test that the correct multi-select values are being submitted