### PR TITLE
Pass --disk-cache-path option to PhantomJS

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -17,6 +17,7 @@ SUPPORTED_ENGINES = {
             'config',
             'debug',
             'disk-cache',
+            'disk-cache-path',
             'ignore-ssl-errors',
             'load-images',
             'load-plugins',

--- a/src/casperjs.cs
+++ b/src/casperjs.cs
@@ -23,6 +23,7 @@ class phantomjs : engine {
             "config",
             "debug",
             "disk-cache",
+            "disk-cache-path",
             "ignore-ssl-errors",
             "load-images",
             "load-plugins",


### PR DESCRIPTION
--disk-cache-path is a new PhantomJS option to specify the location of
the disk cache. See https://github.com/ariya/phantomjs.

#1379