### PR TITLE
Fix assignment of options to engine vs script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clitest:
 	python tests/clitests/runtests.py
 
 clitest-dotNET:
-	python tests/clitests/runtests.py mono casperjs.exe
+	python tests/clitests/runtests.py casperjs.exe
 
 lint:
 	eslint .

--- a/src/casperjs.cs
+++ b/src/casperjs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 
 interface engine {
     string env_varname();
@@ -120,7 +121,7 @@ class casperjs {
         string CASPER_PATH = Path.GetFullPath(Path.Combine(Path.Combine(EXE_FILE, ".."), ".."));
 
         foreach(string arg in args) {
-            if(arg.StartsWith("--engine")) {
+            if(arg.StartsWith("--engine=")) {
                 ENGINE = arg.Substring(9);
                 break;
             }
@@ -136,12 +137,18 @@ class casperjs {
             Environment.Exit(1);
         }
 
+        Regex arg_regex = new Regex("^--([^=]+)(?:=(.*))?$");
+        
         foreach(string arg in args) {
             bool found = false;
-            foreach(string native in ENGINE_NATIVE_ARGS) {
-                if(arg.StartsWith("--" + native)) {
-                    ENGINE_ARGS.Add(arg);
-                    found = true;
+            Match arg_match = arg_regex.Match(arg);
+            if (arg_match.Success) {
+                string arg_name = arg_match.Groups[0].Captures[0].ToString();
+                foreach(string native in ENGINE_NATIVE_ARGS) {
+                    if (arg_name == native) {
+                        ENGINE_ARGS.Add(arg);
+                        found = true;
+                    }
                 }
             }
 

--- a/tests/clitests/runtests.py
+++ b/tests/clitests/runtests.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import platform
 import select
 import signal
 import time
@@ -16,6 +17,7 @@ TEST_ROOT = os.path.abspath(os.path.dirname(__file__))
 CASPERJS_ROOT = os.path.abspath(os.path.join(TEST_ROOT, '..', '..'))
 CASPER_EXEC_FILE = sys.argv[1] if (len(sys.argv) == 2) else 'casperjs'
 CASPER_EXEC = os.path.join(CASPERJS_ROOT, 'bin', CASPER_EXEC_FILE)
+NEEDS_MONO = CASPER_EXEC.endswith('.exe') and platform.system() != 'Windows'
 ENGINE_EXEC = os.environ.get('ENGINE_EXECUTABLE',
                              os.environ.get('PHANTOMJS_EXECUTABLE',
                                             "phantomjs"))
@@ -139,6 +141,8 @@ class CasperExecTestBase(unittest.TestCase):
         failing = kwargs.get('failing', False)
         timeout = kwargs.get('timeout', BASE_TIMEOUT)
         cmd_args = [CASPER_EXEC, '--no-colors'] + cmd.split(' ')
+        if NEEDS_MONO:
+            cmd_args = ['mono'] + cmd_args;
         try:
             cmd = Command(cmd_args)
             out, err = cmd.run(timeout, stderr=subprocess.STDOUT)

--- a/tests/clitests/runtests.py
+++ b/tests/clitests/runtests.py
@@ -19,10 +19,12 @@ CASPER_EXEC = os.path.join(CASPERJS_ROOT, 'bin', CASPER_EXEC_FILE)
 ENGINE_EXEC = os.environ.get('ENGINE_EXECUTABLE',
                              os.environ.get('PHANTOMJS_EXECUTABLE',
                                             "phantomjs"))
-# make it to an absolute path, because some test change the working directory
-# and relative path to phantomjs would be invalid
-if not os.path.isabs(ENGINE_EXEC):
-    os.environ['ENGINE_EXECUTABLE'] = os.path.join(CASPERJS_ROOT, ENGINE_EXEC)
+# Make absolute path to engine executable because some tests change the working directory
+# and relative path to phantomjs would be invalid.
+# Don't make absolute path if the executable is not an actual file path, such as when
+# the engine is in the current search PATH.
+if os.path.exists(ENGINE_EXEC) and not os.path.isabs(ENGINE_EXEC):
+    os.environ['ENGINE_EXECUTABLE'] = os.path.abspath(ENGINE_EXEC)
 
 def exit(message, status):
     print(message)

--- a/tests/clitests/runtests.py
+++ b/tests/clitests/runtests.py
@@ -173,6 +173,16 @@ class CasperExecTestBase(unittest.TestCase):
         else:
             self.assertIn(what, self.runCommand(cmd))
 
+    def assertCommandOutputDoesNotContain(self, cmd, what, **kwargs):
+        if not what:
+            raise AssertionError('Empty lookup')
+        if isinstance(what, (list, tuple)):
+            output = self.runCommand(cmd, **kwargs)
+            for entry in what:
+                self.assertNotIn(entry, output)
+        else:
+            self.assertNotIn(what, self.runCommand(cmd))
+
 
 class BasicCommandsTest(CasperExecTestBase):
     def test_version(self):
@@ -290,6 +300,30 @@ class ScriptOutputTest(CasperExecTestBase):
     def test_simple_script(self):
         script_path = os.path.join(TEST_ROOT, 'scripts', 'script.js')
         self.assertCommandOutputEquals(script_path, 'it works')
+
+
+class ScriptOptionsTest(CasperExecTestBase):
+    def test_script_options(self):
+        script_path = os.path.join(TEST_ROOT, 'scripts', 'options.js')
+        # Specify a mix of engine and script options.
+        # --whoops is special in that it starts with --w, which is a phantomjs engine command.
+        #  At one time was mishandled in src/casperjs.cs.
+        script_path_script_args = script_path + ' --debug=no --load-images=no --whoops --this-is-a=test'
+        self.assertCommandOutputContains(script_path_script_args, [
+            '    "whoops": true,',
+            '    "this-is-a": "test"',
+        ])
+
+    def test_engine_options(self):
+        script_path = os.path.join(TEST_ROOT, 'scripts', 'options.js')
+        # Specify a mix of engine and script options.
+        # --whoops is special in that it starts with --w, which is a phantomjs engine command.
+        #  At one time was mishandled in src/casperjs.cs.
+        script_path_script_args = script_path + ' --debug=no --load-images=no --whoops --this-is-a=test'
+        self.assertCommandOutputDoesNotContain(script_path_script_args, [
+            '    "debug": false,',
+            '    "load-images": false,',
+        ])
 
 
 class ScriptErrorTest(CasperExecTestBase):

--- a/tests/clitests/scripts/options.js
+++ b/tests/clitests/scripts/options.js
@@ -1,0 +1,5 @@
+var require = patchRequire(require);
+var casper = require('casper').create();
+var utils = require('utils');
+utils.dump(casper.cli.options);
+casper.exit();


### PR DESCRIPTION
Consider entire option name, not just initial chars. Fixes #1384. 