### PR TITLE
Mention that npm modules that require node specific features won't work

### DIFF
--- a/docs/writing_modules.rst
+++ b/docs/writing_modules.rst
@@ -40,7 +40,7 @@ From your root casper script::
 
 .. hint::
 
-    Like PhantomJS, CasperJS allows using nodejs modules installed through npm_.
+    CasperJS allows using nodejs modules installed through npm_. Note that since CasperJS uses it's own JavaScript environment, npm modules that use node-specific features will not work under CasperJS.
 
 As an example, let's install the underscore_ library:
 


### PR DESCRIPTION
The current sentence could confuse people into thinking they can load any npm module, eg, see the confusion here:

http://stackoverflow.com/questions/24387854/use-a-node-module-from-casperjs