### PR TITLE
pass encoding (default: utf8) param to openUrl

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -1458,7 +1458,7 @@ To POST some data with utf-8 encoding::
            }
     });
 
-.. versionadded:: 1.0
+.. versionadded:: 1.1
 
 
 You can also set custom request headers to send when performing an outgoing request, passing the ``headers`` option::

--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -1445,6 +1445,22 @@ To pass nested parameters arrays::
 
 .. versionadded:: 1.0
 
+To POST some data with utf-8 encoding::
+
+    casper.open('http://some.testserver.com/post.php', {
+           method: 'post',
+           headers: {
+               'Content-Type': 'application/json; charset=utf-8'
+           },
+           encoding: 'utf8', // not enforced by default
+           data: {
+                'table_flip': '(╯°□°）╯︵ ┻━┻ ',
+           }
+    });
+
+.. versionadded:: 1.0
+
+
 You can also set custom request headers to send when performing an outgoing request, passing the ``headers`` option::
 
     casper.open('http://some.testserver.com/post.php', {

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1440,10 +1440,16 @@ Casper.prototype.open = function open(location, settings) {
     this.page.customHeaders = utils.mergeObjects(utils.clone(baseCustomHeaders), customHeaders);
     // perfom request
     this.browserInitializing = true;
-    this.page.openUrl(this.requestUrl, {
+    var phantomJsSettings = {
         operation: settings.method,
         data:      settings.data
-    }, this.page.settings);
+    };
+    // override any default encoding setting in phantomjs
+    if ('encoding' in settings) {
+        phantomJsSettings.encoding = settings.encoding;
+    }
+
+    this.page.openUrl(this.requestUrl, phantomJsSettings, this.page.settings);
     // revert base custom headers
     this.page.customHeaders = baseCustomHeaders;
     return this;

--- a/tests/suites/casper/open.js
+++ b/tests/suites/casper/open.js
@@ -343,3 +343,40 @@ casper.test.begin('open() PUT tests', 2, {
         });
     }
 });
+
+
+casper.test.begin('open() POST json object with utf8 content', 2, {
+    setUp: setUp,
+    tearDown: tearDown,
+    test: function(test) {
+        casper.open('tests/site/index.html', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+            },
+            encoding: 'utf8',
+            data:   {
+                plop: 42,
+                chuck: 'nórrïs',
+                john: {'Doe': 'ïs here™€'}
+            }
+        }).then(function() {
+            test.pass("Casper.open() can POST a JSON object");
+            test.assertEquals(usedSettings, {
+                method: "POST",
+                encoding: 'utf8',
+                headers: {
+                    'Content-Type': 'application/json; charset=utf-8'
+                },
+                data: '{"plop":42,"chuck":"nórrïs","john":{"Doe":"ïs here™€"}}'
+            }, "Casper.open() used the expected POST settings");
+        });
+
+        casper.run(function() {
+            test.done();
+        });
+    }
+});
+
+
+


### PR DESCRIPTION
Just had some trouble pushing application/json content with utf-8 encoding (got a lot of ��� characters instead of éåî, etc). The only working fix for me is passing { encoding: 'utf8' } to phantomjs' openUrl() method.
Not sure however, if the default param should be 'utf8' or null. The current default of 'utf8' doesn't seem to break anything in my scripts, but perhaps further testing is required.