### PR TITLE
Create DOM node with blank NS to avoid XHTML default in XUnit output

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -726,7 +726,7 @@ exports.ms2seconds = ms2seconds;
  */
 function node(name, attributes) {
     "use strict";
-    var _node   = document.createElement(name);
+    var _node   = document.createElementNS('', name);
     for (var attrName in attributes) {
         var value = attributes[attrName];
         if (attributes.hasOwnProperty(attrName) && isString(attrName)) {

--- a/tests/suites/xunit.js
+++ b/tests/suites/xunit.js
@@ -96,3 +96,17 @@ casper.test.begin('XUnitReporter() can handle custom name attribute for a test c
     test.assertEquals(casper.getElementInfo('failure[type="footype"]').text, 'footext');
     test.done();
 });
+
+casper.test.begin('XUnitReporter() does not have default XML namespace', 1, function suite(test) {
+    var xunit = require('xunit').create();
+    var results = new tester.TestSuiteResult();
+    var suite1 = new tester.TestCaseResult({
+        name: 'foo',
+        file: '/foo'
+    });
+    results.push(suite1);
+    xunit.setResults(results);
+    casper.start().setContent(xunit.getSerializedXML());
+    test.assertNotExists('testsuites[xmlns]');
+    test.done();
+});


### PR DESCRIPTION
When using SlimerJS, the XUnit output is picking up a default XHTML namespace in the `<testsuites/>` element, which can disrupt parsing of test results in CI rigs (e.g. Jenkins).

This change creates the DOM node with an explicit blank namespace in order to suppress this attribute in the serialized output.

Running CasperJS with options: `--engine=slimerjs --xunit="sample-output.xml"`

Sample output before patch:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites xmlns="http://www.w3.org/1999/xhtml" time="86.138">
  <testsuite name="[AC1]" tests="1" failures="0" errors="0" time="3.488" timestamp="2015-09-21T02:55:41.984Z" package="[redacted]">
    <testcase name="HTTP status code is: 200" classname="[redacted]"></testcase>
    <system-out></system-out>
  </testsuite>
</testsuites>
```

Sample output after patch:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites time="56.547">
  <testsuite name="[AC1]" tests="1" failures="0" errors="0" time="1.656" timestamp="2016-02-05T02:29:25.822Z" package="[redacted]">
    <testcase name="HTTP status code is: 200" classname="[redacted]"></testcase>
    <system-out></system-out>
  </testsuite>
</testsuites>
```
q.v. Issue #1322.
