### PR TITLE
refs #1345 - fixed by improving clean method

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2617,7 +2617,7 @@ function createPage(casper) {
             casper.emit('popup.loaded', popupPage);
         };
         popupPage.onClosing = function onClosing(closedPopup) {
-            casper.popups.clean(closedPopup);
+            casper.popups.clean();
             casper.emit('popup.closed', closedPopup);
         };
     };

--- a/modules/pagestack.js
+++ b/modules/pagestack.js
@@ -50,22 +50,20 @@ exports.Stack = Stack;
 Stack.prototype = [];
 
 /**
- * Cleans the stack from closed popup.
+ * Cleans the stack from any closed popups.
  *
- * @param  WebPage  closed  Closed popup page instance
  * @return Number           New stack length
  */
-Stack.prototype.clean = function clean(closed) {
+Stack.prototype.clean = function clean() {
     "use strict";
-    var closedIndex = -1;
+    var self = this;
+
     this.forEach(function(popup, index) {
-        if (closed === popup) {
-            closedIndex = index;
+        // window references lose the parent attribute when they are no longer valid
+        if (popup.parent === null || typeof popup.parent === "undefined") {
+            self.splice(index, 1);
         }
     });
-    if (closedIndex > -1) {
-        this.splice(closedIndex, 1);
-    }
     return this.length;
 };
 

--- a/tests/suites/pagestack.js
+++ b/tests/suites/pagestack.js
@@ -23,7 +23,7 @@ casper.test.begin('pagestack module tests', 14, function(test) {
     test.assertEquals(stack.list().length, 2);
     test.assertEquals(stack.list()[1], page2.url);
 
-    test.assertEquals(stack.clean(page1), 1);
+    test.assertEquals(stack.clean(), 1);
     test.assertEquals(stack[0], page2);
     test.assertEquals(stack.list().length, 1);
     test.assertEquals(stack.list()[0], page2.url);


### PR DESCRIPTION
It was changed so that the clean method is more apt to its name.  It will clean any popups that are not longer valid.

I feel that this is the best way to implement this operation.  I'm pretty sure this won't break BC.