### PR TITLE
Fix encoded urls when using phantomjs 2.1.0 or newer

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1209,7 +1209,9 @@ Casper.prototype.handleReceivedResource = function(resource) {
         return;
     }
     this.resources.push(resource);
-    if (utils.decodeUrl(resource.url) !== this.requestUrl) {
+
+    var checkUrl = utils.ltVersion(phantom.version, '2.1.0') ? utils.decodeUrl(resource.url) : resource.url;
+    if (checkUrl !== this.requestUrl) {
         return;
     }
     this.currentHTTPStatus = null;
@@ -2637,7 +2639,8 @@ function createPage(casper) {
     };
     page.onResourceRequested = function onResourceRequested(requestData, request) {
         casper.emit('resource.requested', requestData, request);
-        if (requestData.url === casper.requestUrl) {
+    	var checkUrl = utils.ltVersion(phantom.version, '2.1.0') ? utils.decodeUrl(requestData.url) : requestData.url;
+        if (checkUrl === casper.requestUrl) {
             casper.emit('page.resource.requested', requestData, request);
         }
         if (utils.isFunction(casper.options.onResourceRequested)) {

--- a/tests/site/has%20space.html
+++ b/tests/site/has%20space.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>CasperJS test url with encoded space</title>
+    </head>
+    <body>
+        <img src="images/phantom.png"/>
+    </body>
+</html>

--- a/tests/suites/casper/encodedurl.js
+++ b/tests/suites/casper/encodedurl.js
@@ -1,0 +1,41 @@
+/*eslint strict:0*/
+
+var urlWithEncodedSpace = 'tests/site/has%20space.html';
+var urlWithoutSpace = 'tests/site/index.html'; 
+
+var urls = [urlWithEncodedSpace, urlWithoutSpace];
+if (casper.cli.options.reverse) urls.reverse();
+
+var phantomVersion = 'phantomjs ' + phantom.version.major + '.' + phantom.version.minor + '.' + phantom.version.patch;
+
+var numPageResourcesRequested = 0;
+var numPageResourcesReceived = 0;
+
+casper.on ('page.resource.requested', function ResourceRequested (resource) {
+   ++numPageResourcesRequested;
+});
+
+casper.on ('page.resource.received', function ResourceReceived (resource) {
+   ++numPageResourcesReceived;
+});
+
+casper.test.begin(phantomVersion + ' ' + urls[0] + ' then ' + urls[1], 8, function(test) {
+
+   casper.start(urls[0], function CheckResponse1(response1) {
+      test.assertEquals(numPageResourcesRequested, 1, 'page.resource.requested 1');
+      test.assertEquals(numPageResourcesReceived, 1, 'page.resource.received 1');
+      test.assertEquals(response1.status, 200, 'status 200 for ' + urls[0]);
+      test.assertEquals(response1.url, casper.filter('open.location', urls[0]) || urls[0], 'opened ' + urls[0]);   // Mimic Casper.prototype.open
+            
+      casper.thenOpen (urls[1], function CheckResponse2(response2) {
+         test.assertEquals(numPageResourcesRequested, 2, 'page.resource.requested 2');
+         test.assertEquals(numPageResourcesReceived, 2, 'page.resource.received 2');
+         test.assertEquals(response2.status, 200, 'status 200 for ' + urls[1]);
+         test.assertEquals(response2.url, casper.filter('open.location', urls[1]) || urls[1], 'opened ' + urls[1]); // Mimic Casper.prototype.open
+      });
+   });
+   
+   casper.run(function() {
+      test.done();
+   });
+});


### PR DESCRIPTION
Fixes #1464. Rebased #1465.