### PR TITLE
refs #824 - utilize an actual xml doc for results

### DIFF
--- a/modules/xunit.js
+++ b/modules/xunit.js
@@ -80,8 +80,15 @@ exports.create = function create() {
  */
 function XUnitExporter() {
     "use strict";
+
+    // Since we are outputting XML, let's do our own document type
+    var documentType = document.implementation.createDocumentType("casperjs", "-//CasperJS//XUnit Test Results", "testsuites");
+
+    this._xmlDocument = document.implementation.createDocument("", "", documentType);
+    this._xml = this._xmlDocument.appendChild(this._xmlDocument.createElement("testsuites"));
+
+    // Initialize everything else
     this.results = undefined;
-    this._xml = utils.node('testsuites');
 }
 exports.XUnitExporter = XUnitExporter;
 
@@ -92,6 +99,9 @@ exports.XUnitExporter = XUnitExporter;
  */
 XUnitExporter.prototype.getXML = function getXML() {
     "use strict";
+
+    var self = this;
+
     if (!(this.results instanceof TestSuiteResult)) {
         throw new CasperError('Results not set, cannot get XML.');
     }
@@ -105,7 +115,7 @@ XUnitExporter.prototype.getXML = function getXML() {
             timestamp: (new Date()).toISOString(),
             'package': generateClassName(result.file)
         });
-        // succesful test cases
+        // successful test cases
         result.passes.forEach(function(success) {
             var testCase = utils.node('testcase', {
                 name: success.message || success.standard,
@@ -124,12 +134,12 @@ XUnitExporter.prototype.getXML = function getXML() {
             var failureNode = utils.node('failure', {
                 type: failure.type || "failure"
             });
-            failureNode.appendChild(document.createTextNode(failure.message || "no message left"));
+            failureNode.appendChild(self._xmlDocument.createCDATASection(failure.message || "no message left"));
             if (failure.values && failure.values.error instanceof Error) {
                 var errorNode = utils.node('error', {
                     type: utils.betterTypeOf(failure.values.error)
                 });
-                errorNode.appendChild(document.createTextNode(failure.values.error.stack));
+                errorNode.appendChild(self._xmlDocument.createCDATASection(failure.values.error.stack));
                 testCase.appendChild(errorNode);
             }
             testCase.appendChild(failureNode);
@@ -140,17 +150,18 @@ XUnitExporter.prototype.getXML = function getXML() {
             var errorNode = utils.node('error', {
                 type: error.name
             });
-            errorNode.appendChild(document.createTextNode(error.stack ? error.stack : error.message));
+            errorNode.appendChild(self._xmlDocument.createCDATASection(error.stack ? error.stack : error.message));
             suiteNode.appendChild(errorNode);
         });
         // warnings
         var warningNode = utils.node('system-out');
-        warningNode.appendChild(document.createTextNode(result.warnings.join('\n')));
+        warningNode.appendChild(self._xmlDocument.createCDATASection(result.warnings.join('\n')));
         suiteNode.appendChild(warningNode);
         this._xml.appendChild(suiteNode);
     }.bind(this));
+
     this._xml.setAttribute('time', utils.ms2seconds(this.results.calculateDuration()));
-    return this._xml;
+    return this._xmlDocument;
 };
 
 /**
@@ -158,10 +169,10 @@ XUnitExporter.prototype.getXML = function getXML() {
  *
  * @return string
  */
-XUnitExporter.prototype.getSerializedXML = function getSerializedXML(xml) {
+XUnitExporter.prototype.getSerializedXML = function getSerializedXML() {
     "use strict";
     var serializer = new XMLSerializer();
-    return '<?xml version="1.0" encoding="UTF-8"?>' + serializer.serializeToString(this.getXML());
+    return '<?xml version="1.0" encoding="UTF-8"?>' + serializer.serializeToString(this._xmlDocument);
 };
 
 /**

--- a/tests/suites/xunit.js
+++ b/tests/suites/xunit.js
@@ -1,17 +1,17 @@
 /*eslint strict:0*/
 var tester = require('tester');
-var testpage = require('webpage').create();
 
 casper.test.begin('XUnitReporter() initialization', 1, function suite(test) {
     var xunit = require('xunit').create();
     var results = new tester.TestSuiteResult();
     xunit.setResults(results);
-    test.assertTruthy(xunit.getSerializedXML());
+    test.assertTruthy(xunit.getSerializedXML(), "XML can be generated");
     test.done();
 });
 
 casper.test.begin('XUnitReporter() can hold test suites', 4, function suite(test) {
     var xunit = require('xunit').create();
+    var xmlDocument;
     var results = new tester.TestSuiteResult();
     var suite1 = new tester.TestCaseResult({
         name: 'foo',
@@ -24,18 +24,20 @@ casper.test.begin('XUnitReporter() can hold test suites', 4, function suite(test
     });
     results.push(suite2);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
-    test.assertEvalEquals(function() {
-        return __utils__.findAll('testsuite').length;
-    }, 2);
-    test.assertExists('testsuites[time]');
-    test.assertExists('testsuite[name="foo"][package="foo"]');
-    test.assertExists('testsuite[name="bar"][package="bar"]');
+    xmlDocument = xunit.getXML();
+
+    casper.start();
+
+    test.assertEquals(xmlDocument.querySelectorAll('testsuite').length, 2, "2 test suites exist");
+    test.assertTruthy(xmlDocument.querySelector('testsuites[time]'), "Element 'testsuites' has time attribute");
+    test.assertTruthy(xmlDocument.querySelector('testsuite[name="foo"][package="foo"]'), "Package foo exists");
+    test.assertTruthy(xmlDocument.querySelector('testsuite[name="bar"][package="bar"]'), "Package bar exists");
     test.done();
 });
 
-casper.test.begin('XUnitReporter() can hold a suite with a succesful test', 1, function suite(test) {
+casper.test.begin('XUnitReporter() can hold a suite with a successful test', 1, function suite(test) {
     var xunit = require('xunit').create();
+    var xmlDocument;
     var results = new tester.TestSuiteResult();
     var suite1 = new tester.TestCaseResult({
         name: 'foo',
@@ -49,13 +51,16 @@ casper.test.begin('XUnitReporter() can hold a suite with a succesful test', 1, f
     });
     results.push(suite1);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
-    test.assertExists('testsuite[name="foo"][package="foo"][tests="1"][failures="0"] testcase[name="footext"]');
+    xmlDocument = xunit.getXML();
+
+    casper.start();
+    test.assertTruthy(xmlDocument.querySelector('testsuite[name="foo"][package="foo"][tests="1"][failures="0"] testcase[name="footext"]'), "Successful test case exists");
     test.done();
 });
 
 casper.test.begin('XUnitReporter() can handle a failed test', 2, function suite(test) {
     var xunit = require('xunit').create();
+    var xmlDocument;
     var results = new tester.TestSuiteResult();
     var suite1 = new tester.TestCaseResult({
         name: 'foo',
@@ -69,14 +74,19 @@ casper.test.begin('XUnitReporter() can handle a failed test', 2, function suite(
     });
     results.push(suite1);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
-    test.assertExists('testsuite[name="foo"][package="foo"][tests="1"][failures="1"] testcase[name="footext"] failure[type="footype"]');
-    test.assertEquals(casper.getElementInfo('failure[type="footype"]').text, 'footext');
+    xmlDocument = xunit.getXML();
+
+    casper.start();
+
+    test.assertTruthy(xmlDocument.querySelector('testsuite[name="foo"][package="foo"][tests="1"][failures="1"] testcase[name="footext"] failure[type="footype"]'), "Failure node exists");
+    test.assertEquals(xmlDocument.querySelector('failure[type="footype"]').textContent, 'footext');
+
     test.done();
 });
 
 casper.test.begin('XUnitReporter() can handle custom name attribute for a test case', 2, function suite(test) {
     var xunit = require('xunit').create();
+    var xmlDocument;
     var results = new tester.TestSuiteResult();
     var suite1 = new tester.TestCaseResult({
         name: 'foo',
@@ -91,14 +101,18 @@ casper.test.begin('XUnitReporter() can handle custom name attribute for a test c
     });
     results.push(suite1);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
-    test.assertExists('testsuite[name="foo"][package="foo"][tests="1"][failures="1"] testcase[name="foo bar baz"] failure[type="footype"]');
-    test.assertEquals(casper.getElementInfo('failure[type="footype"]').text, 'footext');
+    xmlDocument = xunit.getXML();
+
+    casper.start();
+
+    test.assertTruthy(xmlDocument.querySelector('testsuite[name="foo"][package="foo"][tests="1"][failures="1"] testcase[name="foo bar baz"] failure[type="footype"]'), "Failure node exists");
+    test.assertEquals(xmlDocument.querySelector('failure[type="footype"]').textContent, 'footext');
     test.done();
 });
 
 casper.test.begin('XUnitReporter() does not have default XML namespace', 1, function suite(test) {
     var xunit = require('xunit').create();
+    var xmlDocument;
     var results = new tester.TestSuiteResult();
     var suite1 = new tester.TestCaseResult({
         name: 'foo',
@@ -106,7 +120,42 @@ casper.test.begin('XUnitReporter() does not have default XML namespace', 1, func
     });
     results.push(suite1);
     xunit.setResults(results);
-    casper.start().setContent(xunit.getSerializedXML());
-    test.assertNotExists('testsuites[xmlns]');
+    xmlDocument = xunit.getXML();
+
+    casper.start();
+    test.assertFalsy(xmlDocument.querySelector('testsuites[xmlns]'), "No default namespace");
+    test.done();
+});
+
+casper.test.begin('XUnitReporter() can handle markup in nodes', 4, function suite(test) {
+    var xunit = require('xunit').create();
+    var xmlDocument;
+    var results = new tester.TestSuiteResult();
+    var suite1 = new tester.TestCaseResult({
+        name: 'foo',
+        file: '/foo'
+    });
+    suite1.addFailure({
+        success: false,
+        type: "footype",
+        message: "<b>foo</b> <i>bar</i> and <a href=''>baz</a>",
+        file: "/foo",
+        name: "foo bar baz"
+    });
+    suite1.addError({
+        name: 'foo',
+        message: "<b>foo</b> <i>bar</i> and <a href=''>baz</a>"
+    });
+    suite1.addWarning("<b>some warning markup</b>");
+    results.push(suite1);
+    xunit.setResults(results);
+    xmlDocument = xunit.getXML();
+
+    casper.start();
+
+    test.assertTruthy(xmlDocument.querySelector('testsuite[name="foo"][package="foo"][tests="1"][failures="1"] testcase[name="foo bar baz"] failure[type="footype"]'), "Node exists");
+    test.assertEquals(xmlDocument.querySelector('failure[type="footype"]').textContent, "<b>foo</b> <i>bar</i> and <a href=''>baz</a>", "Handles markup in failure node");
+    test.assertEquals(xmlDocument.querySelector('error[type="foo"]').textContent, "<b>foo</b> <i>bar</i> and <a href=''>baz</a>", "Handles markup in error node");
+    test.assertEquals(xmlDocument.querySelector('system-out').textContent, "<b>some warning markup</b>", "Handles markup in error node")
     test.done();
 });


### PR DESCRIPTION
Solving #824 - @istr @mickaelandrieu 

HTMLDocument doesn't like CDATA. Let's use our own custom XML Document instead.

This updates the tests as well as the xunit generation system.

I'm also providing some [sample xml output](https://gist.github.com/BIGjuevos/357986b1ed7469d36b20) from the tests.