### PR TITLE
move to archived versions of phantomjs since bitbucket throttles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,17 @@ language: generic
 
 before_install:
   - echo "Installing $ENGINE $ENGINE_VERSION from $ENGINE_ARCHIVE_URL"
-  - wget $ENGINE_ARCHIVE_URL --output-document=engine.tar.bz2
-  - mkdir engine && tar --strip-components=1 -xvf engine.tar.bz2 -C engine
+  - if [[ $ENGINE_ARCHIVE_URL == *.tar.bz2 ]]; then
+      wget $ENGINE_ARCHIVE_URL --output-document=engine.tar.bz2;
+      bunzip2 engine.tar.bz2;
+    elif [[ $ENGINE_ARCHIVE_URL == *.tar.gz ]]; then
+      wget $ENGINE_ARCHIVE_URL --output-document=engine.tar.gz;
+      gunzip engine.tar.gz;
+    else
+      echo "Unsupported compression type for url $ENGINE_ARCHIVE_URL";
+    fi
+  - mkdir engine
+  - tar --strip-components=1 -xvf engine.tar -C engine
   - if [[ $CASPERJS_ENGINE == 'phantomjs' ]]; then
       export ENGINE_EXECUTABLE="engine/bin/phantomjs";
     elif [[ $CASPERJS_ENGINE == 'slimerjs' ]]; then
@@ -58,21 +67,21 @@ matrix:
       os: linux
     - env: >
         CASPERJS_ENGINE="phantomjs" ENGINE_VERSION="1.9.7" MAKE_TEST_COMMAND="test-dotNET"
-        ENGINE_ARCHIVE_URL="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2"
+        ENGINE_ARCHIVE_URL="https://github.com/BIGjuevos/phantomjs-builds/archive/v1.9.7.tar.gz"
       os: linux
       addons: {apt: {packages: *apt_cs}}
     - env: >
         CASPERJS_ENGINE="phantomjs" ENGINE_VERSION="1.9.7" MAKE_TEST_COMMAND="test"
-        ENGINE_ARCHIVE_URL="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2"
+        ENGINE_ARCHIVE_URL="https://github.com/BIGjuevos/phantomjs-builds/archive/v1.9.7.tar.gz"
       os: linux
     - env: >
         CASPERJS_ENGINE="phantomjs" ENGINE_VERSION="1.9.8" MAKE_TEST_COMMAND="test-dotNET"
-        ENGINE_ARCHIVE_URL="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2"
+        ENGINE_ARCHIVE_URL="https://github.com/BIGjuevos/phantomjs-builds/archive/v1.9.8.tar.gz"
       os: linux
       addons: {apt: {packages: *apt_cs}}
     - env: >
         CASPERJS_ENGINE="phantomjs" ENGINE_VERSION="1.9.8" MAKE_TEST_COMMAND="test"
-        ENGINE_ARCHIVE_URL="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2"
+        ENGINE_ARCHIVE_URL="https://github.com/BIGjuevos/phantomjs-builds/archive/v1.9.8.tar.gz"
       os: linux
     # NOTE: a pre-compiled official 2.0.0 version for linux is not available yet
     # https://bitbucket.org/ariya/phantomjs/downloads
@@ -96,11 +105,11 @@ matrix:
       os: linux
     - env: >
         CASPERJS_ENGINE="phantomjs" ENGINE_VERSION="2.1.1" MAKE_TEST_COMMAND="test"
-        ENGINE_ARCHIVE_URL="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2"
+        ENGINE_ARCHIVE_URL="https://github.com/BIGjuevos/phantomjs-builds/archive/v2.1.1.tar.gz"
       os: linux
     - env: >
         CASPERJS_ENGINE="phantomjs" ENGINE_VERSION="2.1.1" MAKE_TEST_COMMAND="test-dotNET"
-        ENGINE_ARCHIVE_URL="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2"
+        ENGINE_ARCHIVE_URL="https://github.com/BIGjuevos/phantomjs-builds/archive/v2.1.1.tar.gz"
       os: linux
       addons: {apt: {packages: *apt_cs}}
     - env: >


### PR DESCRIPTION
Let's try pulling in phantomjs from somewhere else, and see what happens.  This requires some minor tweaks to the travis yml to like gz files as well.