### PR TITLE
refs #1082 - putting existing PR on top of master

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -47,10 +47,10 @@ SUPPORTED_ENGINES = {
     },
     'slimerjs': {
         'native_args': [
-            'P',
-            'jsconsole',
-            'CreateProfile',
-            'profile',
+            '-P',
+            '-jsconsole',
+            '-CreateProfile',
+            '-profile',
             #phantomjs options
             'cookies-file',
             'config',


### PR DESCRIPTION
SlimerJS has some options that start with - instead of -- and CasperJS will now forward them with this commit.

This is blatant theft from #1082 with just a rebase on top of the current master.