### PR TITLE
Bump to version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "casperjs",
   "description": "A navigation scripting & testing utility for PhantomJS and SlimerJS",
-  "version": "1.1.0-beta5",
+  "version": "1.1.0",
   "keywords": [
     "phantomjs",
     "slimerjs",


### PR DESCRIPTION
I would like to publish 1.1.0-beta6, mainly to publish the updated documentation at http://docs.casperjs.org/en/latest/ ("read the docs" updates when publishing a new release).

@mickaelandrieu @BIGjuevos Please have a look at https://github.com/n1k0/casperjs/releases to review the draft entry and see if you are ok with this. Thank you.
