### PR TITLE
Bump to stable version 1.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,19 +78,21 @@
         <aside class="span4 download">
             <h1>Download</h1>
             <p>
-                CasperJS latest hipstered version is <strong>1.1-beta5</strong>,<br>
-                see the <a href="https://github.com/n1k0/casperjs/releases/tag/1.1-beta5">changelog</a> and
+                CasperJS latest stable version is <strong>1.1.0</strong>,<br>
+                see the <a href="https://github.com/n1k0/casperjs/releases/tag/1.1.0">changelog</a> and
                 <a href="http://docs.casperjs.org/en/latest/upgrading/1.1.html">upgrading documentation</a>.
             </p>
             <div class="dl-links">
-                <p><a href="https://github.com/n1k0/casperjs/zipball/1.1-beta5" class="btn btn-success">
-                    Download 1.1-beta5 (ZIP)
+                <p><a href="https://github.com/n1k0/casperjs/zipball/1.1.0" class="btn btn-success">
+                    Download 1.1.0 (ZIP)
                 </a></p>
             </div>
             <div class="dl-alternate">
                 <p>
-                    CasperJS latest old boring stable version is <strong>1.0.4</strong>,<br>
-                    see the <a href="https://github.com/n1k0/casperjs/releases/tag/1.0.4">changelog</a>.
+                    CasperJS latest old stable version is <strong>1.0.4</strong>,<br>
+                    see the <a href="https://github.com/n1k0/casperjs/releases/tag/1.0.4">changelog</a>.<br>
+                    <em>NOTE: this version is now considered outdated and unmaintained,
+                    just like the PhantomJS versions supported by this release.</em>
                 </p>
                 <div class="dl-links">
                     <p><a href="https://github.com/n1k0/casperjs/zipball/1.0.4" class="btn btn-warning">


### PR DESCRIPTION
Update the github pages to reflect the new release and provide download links.